### PR TITLE
修改服务退出

### DIFF
--- a/migo-rpc-provider/src/main/java/com/nia/rpc/factory/ServerFactoryBean.java
+++ b/migo-rpc-provider/src/main/java/com/nia/rpc/factory/ServerFactoryBean.java
@@ -2,9 +2,10 @@ package com.nia.rpc.factory;
 
 import com.nia.rpc.core.bootstrap.ServerBuilder;
 import com.nia.rpc.core.server.Server;
-import com.nia.rpc.core.server.ServerImpl;
 import lombok.Data;
 import org.springframework.beans.factory.FactoryBean;
+
+import javax.annotation.PreDestroy;
 
 /**
  * Author  知秋
@@ -19,11 +20,11 @@ public class ServerFactoryBean implements FactoryBean<Object>{
     private int port;
     private String serviceName;
     private String zkConn;
-    private ServerImpl rpcServer;
+    private Server rpcServer;
 
     //服务注册并提供
     public void start(){
-        Server rpcServer = ServerBuilder
+        rpcServer = ServerBuilder
                 .builder()
                 .serviceImpl(serviceImpl)
                 .serviceName(serviceName)
@@ -33,6 +34,7 @@ public class ServerFactoryBean implements FactoryBean<Object>{
         rpcServer.start();
     }
     //服务下线
+    @PreDestroy
     public void serviceOffline(){
         rpcServer.shutdown();
     }


### PR DESCRIPTION
1. 在ServerFactoryBean类的start方法中，对属性rpcServer 赋值
   通过PreDestroy注解描述serviceOffline 方法，用于系统退出

2. 在ServerImpl类的registerService方法中，对熟悉curatorFramework赋值，用于在系统退出时，删除在zk上注册的服务地址
